### PR TITLE
fixing IE11 console error

### DIFF
--- a/src/state-machine.js
+++ b/src/state-machine.js
@@ -226,7 +226,7 @@ module.exports = class StateMachine {
      */
     static _debug(...args) {
         if (process.env.NODE_ENV !== 'production') {
-            console.debug.apply(null, ['[DEBUG] [state-machine]', ...args]);
+            console.debug.apply(console, ['[DEBUG] [state-machine]', ...args]);
         }
     }
 
@@ -239,7 +239,7 @@ module.exports = class StateMachine {
      * @returns {undefined} No return value
      */
     static _error(...args) {
-        console.error.apply(null, ['[ERROR] [state-machine]', ...args]);
+        console.error.apply(console, ['[ERROR] [state-machine]', ...args]);
     }
 
     /**


### PR DESCRIPTION
Fixes an IE11 issue where the state machine would not transition unless the developer console was open. This ended up being caused by null being passed to console.debug.apply(). Passing the console instead of null causes IE to transition normally. This was never an issue in production environments because these console statements are only output in lower environments.

**How to test:**
- Use Browserstack or native IE11 to transition a state machine in a non-production environment
- The transition should succeed, and the debug statements should appear in the console